### PR TITLE
feat: support anonymous access to public Confluence data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,19 @@ Generate a Confluence API Token:
 3. Give it a name like **"AI Assistant"**
 4. **Copy the generated token** immediately (you won't see it again!)
 
+> 💡 **Working with a public Confluence site?** You can skip the email and API token steps. Set only `ATLASSIAN_SITE_NAME` and the server will use anonymous access, returning any content that is publicly visible.
+
 ### 2. Try It Instantly
 
 ```bash
 # Set your credentials
 export ATLASSIAN_SITE_NAME="your-company"  # for your-company.atlassian.net
+
+# Optional: only needed for private spaces or pages
 export ATLASSIAN_USER_EMAIL="your.email@company.com"
 export ATLASSIAN_API_TOKEN="your_copied_token"
+
+If you only need public data, set `ATLASSIAN_SITE_NAME` and skip the email/token.
 
 # List your Confluence spaces
 npx -y @aashari/mcp-server-atlassian-confluence ls-spaces
@@ -73,6 +79,8 @@ Add this to your Claude configuration file (`~/.claude/claude_desktop_config.jso
 }
 ```
 
+Only `ATLASSIAN_SITE_NAME` is required. Omit the email and API token if you only need access to public Confluence content.
+
 Restart Claude Desktop, and you'll see "🔗 confluence" in the status bar.
 
 ### For Other AI Assistants
@@ -94,12 +102,14 @@ Create `~/.mcp/configs.json` for system-wide configuration:
   "confluence": {
     "environments": {
       "ATLASSIAN_SITE_NAME": "your-company",
-      "ATLASSIAN_USER_EMAIL": "your.email@company.com", 
+      "ATLASSIAN_USER_EMAIL": "your.email@company.com",
       "ATLASSIAN_API_TOKEN": "your_api_token"
     }
   }
 }
 ```
+
+As above, `ATLASSIAN_SITE_NAME` is mandatory while the user email and API token are optional for private spaces.
 
 **Alternative config keys:** The system also accepts `"atlassian-confluence"`, `"@aashari/mcp-server-atlassian-confluence"`, or `"mcp-server-atlassian-confluence"` instead of `"confluence"`.
 
@@ -161,6 +171,9 @@ Ask your AI assistant:
 3. **Check your site name format**:
    - If your Confluence URL is `https://mycompany.atlassian.net`
    - Your site name should be just `mycompany`
+4. **Using anonymous access?**:
+   - Only publicly shared spaces and pages can be retrieved without credentials
+   - Add `ATLASSIAN_USER_EMAIL` and `ATLASSIAN_API_TOKEN` if the content requires sign-in
 
 ### "Space not found" or "Page not found"
 

--- a/src/cli/atlassian.pages.cli.test.ts
+++ b/src/cli/atlassian.pages.cli.test.ts
@@ -1,5 +1,8 @@
 import { CliTestUtil } from '../utils/cli.test.util.js';
-import { getAtlassianCredentials } from '../utils/transport.util.js';
+import {
+	getAtlassianCredentials,
+	hasAtlassianAuthCredentials,
+} from '../utils/transport.util.js';
 import { config } from '../utils/config.util.js';
 
 describe('Atlassian Confluence Pages CLI Commands', () => {
@@ -10,9 +13,9 @@ describe('Atlassian Confluence Pages CLI Commands', () => {
 
 		// Log warning if credentials aren't available
 		const credentials = getAtlassianCredentials();
-		if (!credentials) {
+		if (!hasAtlassianAuthCredentials(credentials)) {
 			console.warn(
-				'Skipping Atlassian Confluence Pages CLI tests: No credentials available',
+				'Skipping Atlassian Confluence Pages CLI tests: No authenticated credentials available',
 			);
 		}
 	});
@@ -21,12 +24,15 @@ describe('Atlassian Confluence Pages CLI Commands', () => {
 	const skipIfNoCredentials = () => {
 		const credentials = getAtlassianCredentials();
 		// If we're running in CI or test environment, use mock responses instead of skipping
-		if (!credentials && process.env.NODE_ENV === 'test') {
+		if (
+			!hasAtlassianAuthCredentials(credentials) &&
+			process.env.NODE_ENV === 'test'
+		) {
 			// Return false to allow tests to run with potential mocks
 			return false;
 		}
 		// Skip if no credentials are available (for integration tests)
-		return !credentials;
+		return !hasAtlassianAuthCredentials(credentials);
 	};
 
 	// Helper function to get a valid space key for testing

--- a/src/cli/atlassian.search.cli.test.ts
+++ b/src/cli/atlassian.search.cli.test.ts
@@ -1,5 +1,8 @@
 import { CliTestUtil } from '../utils/cli.test.util.js';
-import { getAtlassianCredentials } from '../utils/transport.util.js';
+import {
+	getAtlassianCredentials,
+	hasAtlassianAuthCredentials,
+} from '../utils/transport.util.js';
 import { config } from '../utils/config.util.js';
 
 describe('Atlassian Confluence Search CLI Commands', () => {
@@ -10,15 +13,16 @@ describe('Atlassian Confluence Search CLI Commands', () => {
 
 		// Log warning if credentials aren't available
 		const credentials = getAtlassianCredentials();
-		if (!credentials) {
+		if (!hasAtlassianAuthCredentials(credentials)) {
 			console.warn(
-				'Skipping Atlassian Confluence Search CLI tests: No credentials available',
+				'Skipping Atlassian Confluence Search CLI tests: No authenticated credentials available',
 			);
 		}
 	});
 
 	// Helper function to skip tests when credentials are missing
-	const skipIfNoCredentials = () => !getAtlassianCredentials();
+	const skipIfNoCredentials = () =>
+		!hasAtlassianAuthCredentials(getAtlassianCredentials());
 
 	// Helper function to get a valid space key for testing
 	async function getSpaceKey(): Promise<string | null> {

--- a/src/cli/atlassian.spaces.cli.test.ts
+++ b/src/cli/atlassian.spaces.cli.test.ts
@@ -1,5 +1,8 @@
 import { CliTestUtil } from '../utils/cli.test.util.js';
-import { getAtlassianCredentials } from '../utils/transport.util.js';
+import {
+	getAtlassianCredentials,
+	hasAtlassianAuthCredentials,
+} from '../utils/transport.util.js';
 import { config } from '../utils/config.util.js';
 
 describe('Atlassian Confluence Spaces CLI Commands', () => {
@@ -10,9 +13,9 @@ describe('Atlassian Confluence Spaces CLI Commands', () => {
 
 		// Log warning if credentials aren't available
 		const credentials = getAtlassianCredentials();
-		if (!credentials) {
+		if (!hasAtlassianAuthCredentials(credentials)) {
 			console.warn(
-				'Skipping Atlassian Confluence Spaces CLI tests: No credentials available',
+				'Skipping Atlassian Confluence Spaces CLI tests: No authenticated credentials available',
 			);
 		}
 	});
@@ -20,7 +23,7 @@ describe('Atlassian Confluence Spaces CLI Commands', () => {
 	// Helper function to skip tests when credentials are missing
 	const skipIfNoCredentials = () => {
 		const credentials = getAtlassianCredentials();
-		if (!credentials) {
+		if (!hasAtlassianAuthCredentials(credentials)) {
 			return true;
 		}
 		return false;

--- a/src/controllers/atlassian.pages.controller.test.ts
+++ b/src/controllers/atlassian.pages.controller.test.ts
@@ -1,5 +1,8 @@
 import atlassianPagesController from './atlassian.pages.controller.js';
-import { getAtlassianCredentials } from '../utils/transport.util.js';
+import {
+	getAtlassianCredentials,
+	hasAtlassianAuthCredentials,
+} from '../utils/transport.util.js';
 import { config } from '../utils/config.util.js';
 import { McpError } from '../utils/error.util.js';
 
@@ -10,15 +13,16 @@ describe('Atlassian Pages Controller', () => {
 		config.load();
 
 		const credentials = getAtlassianCredentials();
-		if (!credentials) {
+		if (!hasAtlassianAuthCredentials(credentials)) {
 			console.warn(
-				'Skipping Atlassian Pages Controller tests: No credentials available',
+				'Skipping Atlassian Pages Controller tests: No authenticated credentials available',
 			);
 		}
 	});
 
 	// Helper function to skip tests when credentials are missing
-	const skipIfNoCredentials = () => !getAtlassianCredentials();
+	const skipIfNoCredentials = () =>
+		!hasAtlassianAuthCredentials(getAtlassianCredentials());
 
 	describe('list', () => {
 		it('should return a formatted list of pages', async () => {

--- a/src/controllers/atlassian.search.controller.test.ts
+++ b/src/controllers/atlassian.search.controller.test.ts
@@ -1,5 +1,8 @@
 import atlassianSearchController from './atlassian.search.controller.js';
-import { getAtlassianCredentials } from '../utils/transport.util.js';
+import {
+	getAtlassianCredentials,
+	hasAtlassianAuthCredentials,
+} from '../utils/transport.util.js';
 import { config } from '../utils/config.util.js';
 import { McpError } from '../utils/error.util.js';
 
@@ -10,9 +13,9 @@ describe('Atlassian Search Controller', () => {
 		config.load();
 
 		const credentials = getAtlassianCredentials();
-		if (!credentials) {
+		if (!hasAtlassianAuthCredentials(credentials)) {
 			console.warn(
-				'Skipping Atlassian Search Controller tests: No credentials available',
+				'Skipping Atlassian Search Controller tests: No authenticated credentials available',
 			);
 		}
 	});

--- a/src/controllers/atlassian.spaces.controller.test.ts
+++ b/src/controllers/atlassian.spaces.controller.test.ts
@@ -1,5 +1,8 @@
 import atlassianSpacesController from './atlassian.spaces.controller.js';
-import { getAtlassianCredentials } from '../utils/transport.util.js';
+import {
+	getAtlassianCredentials,
+	hasAtlassianAuthCredentials,
+} from '../utils/transport.util.js';
 import { config } from '../utils/config.util.js';
 import { McpError } from '../utils/error.util.js';
 
@@ -8,15 +11,16 @@ describe('Atlassian Spaces Controller', () => {
 	beforeAll(() => {
 		config.load(); // Ensure config is loaded
 		const credentials = getAtlassianCredentials();
-		if (!credentials) {
+		if (!hasAtlassianAuthCredentials(credentials)) {
 			console.warn(
-				'Skipping Atlassian Spaces Controller tests: No credentials available',
+				'Skipping Atlassian Spaces Controller tests: No authenticated credentials available',
 			);
 		}
 	});
 
 	// Helper function to skip tests when credentials are missing
-	const skipIfNoCredentials = () => !getAtlassianCredentials();
+	const skipIfNoCredentials = () =>
+		!hasAtlassianAuthCredentials(getAtlassianCredentials());
 
 	describe('list', () => {
 		it('should return a formatted list of spaces in Markdown', async () => {

--- a/src/services/vendor.atlassian.comments.service.ts
+++ b/src/services/vendor.atlassian.comments.service.ts
@@ -4,6 +4,7 @@
 
 import { Logger } from '../utils/logger.util.js';
 import {
+	ATLASSIAN_SITE_REQUIRED_MESSAGE,
 	fetchAtlassian,
 	getAtlassianCredentials,
 } from '../utils/transport.util.js';
@@ -46,9 +47,7 @@ async function listPageComments(
 	// Get Atlassian credentials
 	const credentials = getAtlassianCredentials();
 	if (!credentials) {
-		throw createAuthMissingError(
-			'Atlassian credentials are required for this operation',
-		);
+		throw createAuthMissingError(ATLASSIAN_SITE_REQUIRED_MESSAGE);
 	}
 
 	// Set up query parameters

--- a/src/services/vendor.atlassian.pages.service.ts
+++ b/src/services/vendor.atlassian.pages.service.ts
@@ -1,6 +1,7 @@
 import { createApiError, createAuthMissingError } from '../utils/error.util.js';
 import { Logger } from '../utils/logger.util.js';
 import {
+	ATLASSIAN_SITE_REQUIRED_MESSAGE,
 	fetchAtlassian,
 	getAtlassianCredentials,
 } from '../utils/transport.util.js';
@@ -25,7 +26,8 @@ const API_PATH = '/wiki/api/v2';
  * @namespace VendorAtlassianPagesService
  * @description Service for interacting with Confluence Pages API.
  * Provides methods for listing pages and retrieving page details.
- * All methods require valid Atlassian credentials configured in the environment.
+ * Requires ATLASSIAN_SITE_NAME to be configured. Provide ATLASSIAN_USER_EMAIL and
+ * ATLASSIAN_API_TOKEN for accessing non-public content.
  */
 
 /**
@@ -231,9 +233,7 @@ async function list(
 
 	const credentials = getAtlassianCredentials();
 	if (!credentials) {
-		throw createAuthMissingError(
-			'Atlassian credentials are required for this operation',
-		);
+		throw createAuthMissingError(ATLASSIAN_SITE_REQUIRED_MESSAGE);
 	}
 
 	// Build query parameters
@@ -373,9 +373,7 @@ async function get(
 
 	const credentials = getAtlassianCredentials();
 	if (!credentials) {
-		throw createAuthMissingError(
-			'Atlassian credentials are required for this operation',
-		);
+		throw createAuthMissingError(ATLASSIAN_SITE_REQUIRED_MESSAGE);
 	}
 
 	// Build query parameters

--- a/src/services/vendor.atlassian.pages.test.ts
+++ b/src/services/vendor.atlassian.pages.test.ts
@@ -1,5 +1,8 @@
 import pagesService from './vendor.atlassian.pages.service.js';
-import { getAtlassianCredentials } from '../utils/transport.util.js';
+import {
+	getAtlassianCredentials,
+	hasAtlassianAuthCredentials,
+} from '../utils/transport.util.js';
 import { config } from '../utils/config.util.js';
 
 describe('Vendor Atlassian Pages Service', () => {
@@ -10,15 +13,16 @@ describe('Vendor Atlassian Pages Service', () => {
 
 		// Log a warning if credentials aren't available
 		const credentials = getAtlassianCredentials();
-		if (!credentials) {
+		if (!hasAtlassianAuthCredentials(credentials)) {
 			console.warn(
-				'Skipping Atlassian Pages tests: No credentials available',
+				'Skipping Atlassian Pages tests: No authenticated credentials available',
 			);
 		}
 	});
 
 	// Helper function to skip tests when credentials are missing
-	const skipIfNoCredentials = () => !getAtlassianCredentials();
+	const skipIfNoCredentials = () =>
+		!hasAtlassianAuthCredentials(getAtlassianCredentials());
 
 	// Use standard describe and skip inside test if needed
 	describe('list', () => {

--- a/src/services/vendor.atlassian.search.test.ts
+++ b/src/services/vendor.atlassian.search.test.ts
@@ -1,7 +1,10 @@
 // vendor.atlassian.search.test.ts
 
 import atlassianSearchService from './vendor.atlassian.search.service.js';
-import { getAtlassianCredentials } from '../utils/transport.util.js';
+import {
+	getAtlassianCredentials,
+	hasAtlassianAuthCredentials,
+} from '../utils/transport.util.js';
 import { config } from '../utils/config.util.js';
 import { McpError } from '../utils/error.util.js';
 
@@ -10,9 +13,9 @@ describe('Vendor Atlassian Search Service', () => {
 	beforeAll(() => {
 		config.load(); // Ensure config is loaded
 		const credentials = getAtlassianCredentials();
-		if (!credentials) {
+		if (!hasAtlassianAuthCredentials(credentials)) {
 			console.warn(
-				'Skipping Atlassian Search Service tests: No credentials available',
+				'Skipping Atlassian Search Service tests: No authenticated credentials available',
 			);
 		}
 	});
@@ -20,7 +23,7 @@ describe('Vendor Atlassian Search Service', () => {
 	// Helper function to skip tests when credentials are missing
 	const skipIfNoCredentials = () => {
 		const credentials = getAtlassianCredentials();
-		return !credentials;
+		return !hasAtlassianAuthCredentials(credentials);
 	};
 
 	describe('search', () => {

--- a/src/services/vendor.atlassian.spaces.service.ts
+++ b/src/services/vendor.atlassian.spaces.service.ts
@@ -1,6 +1,7 @@
 import { createApiError, createAuthMissingError } from '../utils/error.util.js';
 import { Logger } from '../utils/logger.util.js';
 import {
+	ATLASSIAN_SITE_REQUIRED_MESSAGE,
 	fetchAtlassian,
 	getAtlassianCredentials,
 } from '../utils/transport.util.js';
@@ -23,7 +24,8 @@ const API_PATH = '/wiki/api/v2';
  * @namespace VendorAtlassianSpacesService
  * @description Service for interacting with Confluence Spaces API.
  * Provides methods for listing spaces and retrieving space details.
- * All methods require valid Atlassian credentials configured in the environment.
+ * Requires ATLASSIAN_SITE_NAME to be configured. Provide ATLASSIAN_USER_EMAIL and
+ * ATLASSIAN_API_TOKEN for accessing non-public content.
  */
 
 /**
@@ -69,9 +71,7 @@ async function list(
 
 	const credentials = getAtlassianCredentials();
 	if (!credentials) {
-		throw createAuthMissingError(
-			'Atlassian credentials are required for this operation',
-		);
+		throw createAuthMissingError(ATLASSIAN_SITE_REQUIRED_MESSAGE);
 	}
 
 	// Build query parameters
@@ -204,9 +204,7 @@ async function get(
 
 	const credentials = getAtlassianCredentials();
 	if (!credentials) {
-		throw createAuthMissingError(
-			'Atlassian credentials are required for this operation',
-		);
+		throw createAuthMissingError(ATLASSIAN_SITE_REQUIRED_MESSAGE);
 	}
 
 	// Build query parameters

--- a/src/services/vendor.atlassian.spaces.test.ts
+++ b/src/services/vendor.atlassian.spaces.test.ts
@@ -1,5 +1,8 @@
 import atlassianSpacesService from './vendor.atlassian.spaces.service.js';
-import { getAtlassianCredentials } from '../utils/transport.util.js';
+import {
+	getAtlassianCredentials,
+	hasAtlassianAuthCredentials,
+} from '../utils/transport.util.js';
 import { config } from '../utils/config.util.js';
 import { McpError } from '../utils/error.util.js';
 
@@ -8,15 +11,16 @@ describe('Vendor Atlassian Spaces Service', () => {
 	beforeAll(() => {
 		config.load(); // Ensure config is loaded
 		const credentials = getAtlassianCredentials();
-		if (!credentials) {
+		if (!hasAtlassianAuthCredentials(credentials)) {
 			console.warn(
-				'Skipping Atlassian Spaces Service tests: No credentials available',
+				'Skipping Atlassian Spaces Service tests: No authenticated credentials available',
 			);
 		}
 	});
 
 	// Helper function to skip tests when credentials are missing
-	const skipIfNoCredentials = () => !getAtlassianCredentials();
+	const skipIfNoCredentials = () =>
+		!hasAtlassianAuthCredentials(getAtlassianCredentials());
 
 	describe('list', () => {
 		it('should return a list of spaces', async () => {

--- a/src/utils/error.util.ts
+++ b/src/utils/error.util.ts
@@ -250,8 +250,9 @@ export function handleCliError(error: unknown): never {
 		cliLines.push(
 			'Tip: Make sure to set up your Atlassian credentials in the configuration file or environment variables:',
 		);
+		cliLines.push('- ATLASSIAN_SITE_NAME (required)');
 		cliLines.push(
-			'- ATLASSIAN_SITE_NAME, ATLASSIAN_USER_EMAIL, and ATLASSIAN_API_TOKEN',
+			'- ATLASSIAN_USER_EMAIL and ATLASSIAN_API_TOKEN (optional, required for private content)',
 		);
 	} else if (mcpError.type === ErrorType.AUTH_INVALID) {
 		cliLines.push(


### PR DESCRIPTION
## Summary
- allow `getAtlassianCredentials` to return site-only configuration and add a helper for detecting full auth credentials
- require the Confluence site name across services while letting requests omit Basic auth when anonymous access is sufficient
- refresh tests and documentation to reflect optional credentials for public Confluence usage

## Testing
- npm test -- --runTestsByPath src/utils/transport.util.test.ts
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c91332b8dc833388d804486d3b1a1b