### PR TITLE
feat: add universal search tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npx -y @aashari/mcp-server-atlassian-confluence get-space --space-key DEV
 # Search for pages
 npx -y @aashari/mcp-server-atlassian-confluence search --query "API documentation"
 
-# Search across pages, spaces, attachments, and comments in one go
+# Search across pages, spaces, attachments, and comments in one go (titles + full content)
 npx -y @aashari/mcp-server-atlassian-confluence search-all --query "incident response"
 ```
 
@@ -134,7 +134,7 @@ Ask your AI assistant:
 - *"Find all documentation with 'security' in the title"*
 - *"Show me pages labeled with 'getting-started'"*
 - *"Search for content in the DEV space about deployment"*
-- *"Run a universal search for 'incident response' across spaces, pages, attachments, and comments"*
+- *"Run a universal search for 'incident response' across spaces, pages, attachments, and comments (matches titles and body content automatically)"*
 
 ### 📄 Access Specific Content
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Transform how you access and interact with your team's knowledge by connecting C
 ✅ **Search across all spaces**: *"Find all pages about security best practices"*  
 ✅ **Get instant answers**: *"Show me the latest release notes from the Product space"*  
 ✅ **Access team knowledge**: *"What are our HR policies for remote work?"*  
-✅ **Review page comments**: *"Show me the discussion on the architecture document"*  
-✅ **Find specific content**: *"Search for pages with 'onboarding' in the title"*  
+✅ **Review page comments**: *"Show me the discussion on the architecture document"*
+✅ **Find specific content**: *"Search for pages with 'onboarding' in the title"*
+✅ **Run universal search**: *"Show pages, spaces, attachments, and comments about Kubernetes"*
 
 ## Perfect For
 
@@ -55,6 +56,9 @@ npx -y @aashari/mcp-server-atlassian-confluence get-space --space-key DEV
 
 # Search for pages
 npx -y @aashari/mcp-server-atlassian-confluence search --query "API documentation"
+
+# Search across pages, spaces, attachments, and comments in one go
+npx -y @aashari/mcp-server-atlassian-confluence search-all --query "incident response"
 ```
 
 ## Connect to AI Assistants
@@ -130,6 +134,7 @@ Ask your AI assistant:
 - *"Find all documentation with 'security' in the title"*
 - *"Show me pages labeled with 'getting-started'"*
 - *"Search for content in the DEV space about deployment"*
+- *"Run a universal search for 'incident response' across spaces, pages, attachments, and comments"*
 
 ### 📄 Access Specific Content
 

--- a/src/cli/atlassian.universal-search.cli.test.ts
+++ b/src/cli/atlassian.universal-search.cli.test.ts
@@ -1,0 +1,55 @@
+import { CliTestUtil } from '../utils/cli.test.util.js';
+import {
+	getAtlassianCredentials,
+	hasAtlassianAuthCredentials,
+} from '../utils/transport.util.js';
+import { config } from '../utils/config.util.js';
+
+describe('Confluence Universal Search CLI Command', () => {
+	beforeAll(() => {
+		config.load();
+
+		const credentials = getAtlassianCredentials();
+		if (!hasAtlassianAuthCredentials(credentials)) {
+			console.warn(
+				'Skipping universal search CLI tests: No authenticated credentials available',
+			);
+		}
+	});
+
+	const skipIfNoCredentials = () =>
+		!hasAtlassianAuthCredentials(getAtlassianCredentials());
+
+	it('should run universal search with default content types', async () => {
+		if (skipIfNoCredentials()) {
+			return;
+		}
+
+		const result = await CliTestUtil.runCommand([
+			'search-all',
+			'--query',
+			'a',
+			'--limit-per-type',
+			'1',
+		]);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('Confluence Universal Search');
+		expect(result.stdout).toContain('Search Summary');
+	}, 30000);
+
+	it('should validate limit per type input', async () => {
+		const result = await CliTestUtil.runCommand([
+			'search-all',
+			'--query',
+			'anything',
+			'--limit-per-type',
+			'0',
+		]);
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain(
+			'Invalid --limit-per-type value: Must be a positive integer.',
+		);
+	});
+});

--- a/src/cli/atlassian.universal-search.cli.ts
+++ b/src/cli/atlassian.universal-search.cli.ts
@@ -1,0 +1,106 @@
+import { Command } from 'commander';
+import { Logger } from '../utils/logger.util.js';
+import { handleCliError } from '../utils/error.util.js';
+import atlassianUniversalSearchController from '../controllers/atlassian.universal-search.controller.js';
+import { UniversalSearchToolArgsType } from '../tools/atlassian.universal-search.types.js';
+
+function register(program: Command): void {
+	const cliLogger = Logger.forContext(
+		'cli/atlassian.universal-search.cli.ts',
+		'register',
+	);
+	cliLogger.debug('Registering universal search CLI commands...');
+
+	program
+		.command('search-all')
+		.description(
+			'Search across pages, blog posts, spaces, attachments, and comments in one command.',
+		)
+		.requiredOption(
+			'-q, --query <text>',
+			'Text to search for across Confluence content. Required.',
+		)
+		.option(
+			'--space-key <key>',
+			'Restrict results (pages, blog posts, attachments, comments) to a specific space key.',
+		)
+		.option(
+			'--labels <labels...>',
+			'Require these labels on page and blog post results (all labels must match).',
+		)
+		.option(
+			'--limit-per-type <number>',
+			'Maximum number of results to return per content type (1-25). Defaults to 5.',
+			'5',
+		)
+		.option(
+			'--no-spaces',
+			'Exclude spaces from the universal search results.',
+		)
+		.option(
+			'--no-pages',
+			'Exclude pages from the universal search results.',
+		)
+		.option(
+			'--no-blog-posts',
+			'Exclude blog posts from the universal search results.',
+		)
+		.option(
+			'--no-attachments',
+			'Exclude attachments from the universal search results.',
+		)
+		.option(
+			'--no-comments',
+			'Exclude comments from the universal search results.',
+		)
+		.action(async (options) => {
+			const actionLogger = Logger.forContext(
+				'cli/atlassian.universal-search.cli.ts',
+				'searchAll',
+			);
+			try {
+				actionLogger.debug('Processing command options:', options);
+
+				const limitPerType = parseInt(options.limitPerType, 10);
+				if (Number.isNaN(limitPerType) || limitPerType <= 0) {
+					throw new Error(
+						'Invalid --limit-per-type value: Must be a positive integer.',
+					);
+				}
+				if (limitPerType > 25) {
+					throw new Error(
+						'Invalid --limit-per-type value: Maximum allowed is 25.',
+					);
+				}
+
+				const searchOptions: UniversalSearchToolArgsType = {
+					query: options.query,
+					spaceKey: options.spaceKey,
+					labels: options.labels,
+					includeSpaces: options.spaces,
+					includePages: options.pages,
+					includeBlogPosts: options.blogPosts,
+					includeAttachments: options.attachments,
+					includeComments: options.comments,
+					limitPerType,
+				};
+
+				actionLogger.debug(
+					'Executing universal search with options:',
+					searchOptions,
+				);
+
+				const result =
+					await atlassianUniversalSearchController.search(
+						searchOptions,
+					);
+
+				console.log(result.content);
+			} catch (error) {
+				actionLogger.error('Universal search failed:', error);
+				handleCliError(error);
+			}
+		});
+}
+
+export default { register };

--- a/src/cli/atlassian.universal-search.cli.ts
+++ b/src/cli/atlassian.universal-search.cli.ts
@@ -18,7 +18,7 @@ function register(program: Command): void {
 		)
 		.requiredOption(
 			'-q, --query <text>',
-			'Text to search for across Confluence content. Required.',
+			'Text to search for across Confluence titles and full content. Required.',
 		)
 		.option(
 			'--space-key <key>',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import atlassianSpacesCli from './atlassian.spaces.cli.js';
 import atlassianPagesCli from './atlassian.pages.cli.js';
 import atlassianSearchCli from './atlassian.search.cli.js';
 import atlassianCommentsCli from './atlassian.comments.cli.js';
+import atlassianUniversalSearchCli from './atlassian.universal-search.cli.js';
 
 // Package description
 const DESCRIPTION =
@@ -25,6 +26,7 @@ export async function runCli(args: string[]) {
 	atlassianSpacesCli.register(program);
 	atlassianPagesCli.register(program);
 	atlassianSearchCli.register(program);
+	atlassianUniversalSearchCli.register(program);
 	atlassianCommentsCli.register(program);
 	cliLogger.debug('All CLI commands registered successfully');
 

--- a/src/controllers/atlassian.search.controller.ts
+++ b/src/controllers/atlassian.search.controller.ts
@@ -13,24 +13,12 @@ import { SearchToolArgsType } from '../tools/atlassian.search.types.js';
 import { buildErrorContext } from '../utils/error-handler.util.js';
 import { ensureMcpError } from '../utils/error.util.js';
 import { formatHeading, formatPagination } from '../utils/formatter.util.js';
+import { escapeCqlValue } from '../utils/cql.util.js';
 
 const controllerLogger = Logger.forContext(
 	'controllers/atlassian.search.controller.ts',
 );
 controllerLogger.debug('Search controller initialized');
-
-/**
- * Escapes special characters in a string for safe use within CQL quotes.
- * Uses JSON.stringify to handle escaping and removes the outer quotes.
- * @param value The string to escape.
- * @returns Escaped string, suitable for placing inside CQL double quotes.
- */
-function escapeCqlValue(value: string): string {
-	// JSON.stringify correctly escapes quotes, backslashes, etc.
-	const jsonString = JSON.stringify(value);
-	// Remove the leading and trailing double quotes added by stringify
-	return jsonString.slice(1, -1);
-}
 
 /**
  * Builds a CQL query string from provided options.

--- a/src/controllers/atlassian.search.formatter.ts
+++ b/src/controllers/atlassian.search.formatter.ts
@@ -12,6 +12,60 @@ import {
  * @param searchData - Raw search results from the API
  * @returns Formatted string with search results in markdown format
  */
+export function formatSearchResultItem(result: SearchResultType): string {
+	const itemLines: string[] = [];
+
+	const title = result.title || result.content?.title || 'Untitled Result';
+
+	const properties: Record<string, unknown> = {
+		ID: result.content?.id || result.id || 'N/A',
+		Type: result.content?.type || result.entityType || 'N/A',
+		Status: result.content?.status || 'N/A',
+		Space:
+			result.space?.name || result.resultGlobalContainer?.title || 'N/A',
+	};
+
+	if (result.space?.id) {
+		properties['Space ID'] = result.space.id;
+	}
+
+	const url =
+		result.url ||
+		result.content?._links?.webui ||
+		result.resultGlobalContainer?.displayUrl;
+
+	if (url) {
+		properties['URL'] = {
+			url,
+			title: 'View in Confluence',
+		};
+	}
+
+	const excerpt = result.excerpt || result.content?.excerpt?.content;
+
+	if (excerpt) {
+		properties['Excerpt'] = excerpt;
+	}
+
+	const modified =
+		result.lastModified ||
+		result.content?.lastModified ||
+		result.friendlyLastModified;
+
+	if (modified) {
+		try {
+			properties['Modified'] = formatDate(new Date(modified));
+		} catch {
+			properties['Modified'] = modified;
+		}
+	}
+
+	itemLines.push(formatHeading(title, 2));
+	itemLines.push(formatBulletList(properties, (key) => key));
+
+	return itemLines.join('\n');
+}
+
 export function formatSearchResults(searchData: SearchResultType[]): string {
 	if (searchData.length === 0) {
 		return (
@@ -25,80 +79,12 @@ export function formatSearchResults(searchData: SearchResultType[]): string {
 
 	const lines: string[] = [formatHeading('Confluence Search Results', 1), ''];
 
-	// Use the numbered list formatter for consistent formatting
-	const formattedList = formatNumberedList(searchData, (result) => {
-		const itemLines: string[] = [];
-
-		// Handle both v1 and v2 API result formats
-		// For v1 API, result.title is directly available
-		// For v2 API, title is in content object
-
-		// Get title from either direct property or content object
-		const title =
-			result.title || result.content?.title || 'Untitled Result';
-
-		// Create an object with properties, handling optional fields
-		const properties: Record<string, unknown> = {
-			// Use optional chaining and fallbacks for all fields
-			ID: result.content?.id || result.id || 'N/A',
-			Type: result.content?.type || result.entityType || 'N/A',
-			Status: result.content?.status || 'N/A',
-			Space:
-				result.space?.name ||
-				result.resultGlobalContainer?.title ||
-				'N/A',
-		};
-
-		// Add Space ID only if available
-		if (result.space?.id) {
-			properties['Space ID'] = result.space.id;
-		}
-
-		// Add URL with proper handling of optional fields
-		const url =
-			result.url ||
-			result.content?._links?.webui ||
-			result.resultGlobalContainer?.displayUrl;
-
-		if (url) {
-			properties['URL'] = {
-				url: url,
-				title: 'View in Confluence',
-			};
-		}
-
-		// Add excerpt if available, with proper handling of both API formats
-		const excerpt = result.excerpt || result.content?.excerpt?.content;
-
-		if (excerpt) {
-			properties['Excerpt'] = excerpt;
-		}
-
-		// Add modification date if available
-		const modified =
-			result.lastModified ||
-			result.content?.lastModified ||
-			result.friendlyLastModified;
-
-		if (modified) {
-			// Attempt to format date, fallback to original string
-			try {
-				properties['Modified'] = formatDate(new Date(modified));
-			} catch {
-				properties['Modified'] = modified; // Fallback if parsing fails
-			}
-		}
-
-		// Create the formatted output
-		itemLines.push(formatHeading(title, 2));
-		itemLines.push(formatBulletList(properties, (key) => key));
-
-		return itemLines.join('\n');
-	});
+	const formattedList = formatNumberedList(searchData, (result) =>
+		formatSearchResultItem(result),
+	);
 
 	lines.push(formattedList);
 
-	// Add standard footer with timestamp
 	lines.push('\n\n' + formatSeparator());
 	lines.push(`*Information retrieved at: ${formatDate(new Date())}*`);
 

--- a/src/controllers/atlassian.universal-search.controller.test.ts
+++ b/src/controllers/atlassian.universal-search.controller.test.ts
@@ -1,0 +1,50 @@
+import atlassianUniversalSearchController from './atlassian.universal-search.controller.js';
+import atlassianSearchService from '../services/vendor.atlassian.search.service.js';
+import type {
+	SearchParams,
+	SearchResponseType,
+} from '../services/vendor.atlassian.search.types.js';
+
+describe('atlassian.universal-search.controller', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('searches titles first and falls back to full content for non-space types', async () => {
+		const emptyResponse: SearchResponseType = {
+			results: [],
+		};
+
+		const searchMock = jest
+			.spyOn(atlassianSearchService, 'search')
+			.mockResolvedValue(emptyResponse);
+
+		const response = await atlassianUniversalSearchController.search({
+			query: 'incident',
+		});
+
+		expect(response.content).toContain('Confluence Universal Search');
+		expect(searchMock).toHaveBeenCalled();
+
+		const spaceCall = searchMock.mock.calls.find(([params]) =>
+			params.cql.includes('type = space'),
+		);
+		expect(spaceCall).toBeDefined();
+		const [spaceParams] = spaceCall as [SearchParams];
+		expect(spaceParams.cql).toContain('title ~ "incident"');
+		expect(spaceParams.cql).not.toContain('OR text');
+
+		const contentTypes = ['page', 'blogpost', 'attachment', 'comment'];
+
+		for (const expectedType of contentTypes) {
+			const typeCall = searchMock.mock.calls.find(([params]) =>
+				params.cql.includes(`type = ${expectedType}`),
+			);
+			expect(typeCall).toBeDefined();
+			const [typeParams] = typeCall as [SearchParams];
+			expect(typeParams.cql).toContain(
+				'(title ~ "incident" OR text ~ "incident")',
+			);
+		}
+	});
+});

--- a/src/controllers/atlassian.universal-search.controller.ts
+++ b/src/controllers/atlassian.universal-search.controller.ts
@@ -1,0 +1,228 @@
+import { Logger } from '../utils/logger.util.js';
+import {
+	handleControllerError,
+	buildErrorContext,
+} from '../utils/error-handler.util.js';
+import { ControllerResponse } from '../types/common.types.js';
+import atlassianSearchService from '../services/vendor.atlassian.search.service.js';
+import {
+	SearchParams,
+	SearchResultType,
+} from '../services/vendor.atlassian.search.types.js';
+import { escapeCqlValue } from '../utils/cql.util.js';
+import {
+	formatUniversalSearchResults,
+	UniversalSearchSectionKey,
+} from './atlassian.universal-search.formatter.js';
+import { UniversalSearchToolArgsType } from '../tools/atlassian.universal-search.types.js';
+import { ensureMcpError } from '../utils/error.util.js';
+
+const controllerLogger = Logger.forContext(
+	'controllers/atlassian.universal-search.controller.ts',
+);
+
+const DEFAULT_LIMIT_PER_TYPE = 5;
+
+type NormalizedUniversalOptions = {
+	query: string;
+	spaceKey?: string;
+	labels?: string[];
+	includeSpaces: boolean;
+	includePages: boolean;
+	includeBlogPosts: boolean;
+	includeAttachments: boolean;
+	includeComments: boolean;
+	limitPerType: number;
+};
+
+const SECTION_TO_CQL_TYPE: Record<UniversalSearchSectionKey, string> = {
+	spaces: 'space',
+	pages: 'page',
+	blogPosts: 'blogpost',
+	attachments: 'attachment',
+	comments: 'comment',
+};
+
+function normalizeOptions(
+	options: UniversalSearchToolArgsType,
+): NormalizedUniversalOptions {
+	const trimmedQuery = options.query?.trim() ?? '';
+
+	return {
+		query: trimmedQuery,
+		spaceKey: options.spaceKey?.trim() || undefined,
+		labels:
+			options.labels
+				?.map((label) => label.trim())
+				.filter((label) => label.length > 0) || undefined,
+		includeSpaces:
+			options.includeSpaces !== undefined ? options.includeSpaces : true,
+		includePages:
+			options.includePages !== undefined ? options.includePages : true,
+		includeBlogPosts:
+			options.includeBlogPosts !== undefined
+				? options.includeBlogPosts
+				: true,
+		includeAttachments:
+			options.includeAttachments !== undefined
+				? options.includeAttachments
+				: true,
+		includeComments:
+			options.includeComments !== undefined
+				? options.includeComments
+				: true,
+		limitPerType:
+			options.limitPerType !== undefined
+				? Math.min(Math.max(options.limitPerType, 1), 25)
+				: DEFAULT_LIMIT_PER_TYPE,
+	} satisfies NormalizedUniversalOptions;
+}
+
+function buildTypeSpecificCql(
+	type: UniversalSearchSectionKey,
+	options: NormalizedUniversalOptions,
+): string {
+	const clauses: string[] = [];
+
+	clauses.push(`type = ${SECTION_TO_CQL_TYPE[type]}`);
+	clauses.push(`text ~ "${escapeCqlValue(options.query)}"`);
+
+	if (type !== 'spaces' && options.spaceKey) {
+		clauses.push(`space = "${escapeCqlValue(options.spaceKey)}"`);
+	}
+
+	if (options.labels && (type === 'pages' || type === 'blogPosts')) {
+		for (const label of options.labels) {
+			clauses.push(`label = "${escapeCqlValue(label)}"`);
+		}
+	}
+
+	return clauses.join(' AND ');
+}
+
+async function executeSearchForType(
+	type: UniversalSearchSectionKey,
+	options: NormalizedUniversalOptions,
+): Promise<SearchResultType[]> {
+	const cql = buildTypeSpecificCql(type, options);
+
+	controllerLogger.debug(
+		`Executing universal search for ${type} with CQL: ${cql}`,
+	);
+
+	const params: SearchParams = {
+		cql,
+		limit: options.limitPerType,
+		excerpt: 'highlight',
+		includeArchivedSpaces: false,
+	};
+
+	const response = await atlassianSearchService.search(params);
+
+	return response.results || [];
+}
+
+async function search(
+	options: UniversalSearchToolArgsType,
+): Promise<ControllerResponse> {
+	const methodLogger = controllerLogger.forMethod('search');
+	methodLogger.debug('Received universal search options:', options);
+
+	if (!options.query || options.query.trim().length === 0) {
+		methodLogger.warn('Universal search called without a query string.');
+		return {
+			content:
+				'Please provide a search query (for example: `--query "design"`).',
+		};
+	}
+
+	let normalizedOptions: NormalizedUniversalOptions | null = null;
+
+	try {
+		normalizedOptions = normalizeOptions(options);
+
+		const includedTypes = (
+			[
+				['spaces', normalizedOptions.includeSpaces],
+				['pages', normalizedOptions.includePages],
+				['blogPosts', normalizedOptions.includeBlogPosts],
+				['attachments', normalizedOptions.includeAttachments],
+				['comments', normalizedOptions.includeComments],
+			] as Array<[UniversalSearchSectionKey, boolean]>
+		)
+			.filter(([, include]) => include)
+			.map(([key]) => key);
+
+		if (includedTypes.length === 0) {
+			methodLogger.warn(
+				'Universal search called with no content types enabled.',
+			);
+			return {
+				content:
+					'No content types selected. Enable at least one type (pages, spaces, blog posts, attachments, or comments).',
+			};
+		}
+
+		const searchPromises = includedTypes.map(async (type) => {
+			const results = await executeSearchForType(
+				type,
+				normalizedOptions!,
+			);
+			return [type, results] as const;
+		});
+
+		const resolvedResults = await Promise.all(searchPromises);
+
+		const resultsByType: Record<
+			UniversalSearchSectionKey,
+			SearchResultType[]
+		> = {
+			spaces: [],
+			pages: [],
+			blogPosts: [],
+			attachments: [],
+			comments: [],
+		};
+
+		for (const [type, results] of resolvedResults) {
+			resultsByType[type] = results;
+		}
+
+		const content = formatUniversalSearchResults({
+			query: normalizedOptions.query,
+			spaceKey: normalizedOptions.spaceKey,
+			labels: normalizedOptions.labels,
+			limitPerType: normalizedOptions.limitPerType,
+			includedTypes,
+			results: resultsByType,
+		});
+
+		return { content };
+	} catch (error) {
+		const mcpError = ensureMcpError(error);
+		if (mcpError.statusCode === 400) {
+			mcpError.message = `Universal search failed (Status 400 - Bad Request): ${mcpError.message}. This may indicate invalid CQL generated from the provided filters. Double-check the query text and filters.`;
+		}
+
+		throw handleControllerError(
+			mcpError,
+			buildErrorContext(
+				'Universal search',
+				'performing',
+				'controllers/atlassian.universal-search.controller.ts@search',
+				{
+					query: options.query,
+				},
+				{
+					limitPerType:
+						normalizedOptions?.limitPerType ??
+						options.limitPerType ??
+						DEFAULT_LIMIT_PER_TYPE,
+					spaceKey: normalizedOptions?.spaceKey || options.spaceKey,
+				},
+			),
+		);
+	}
+}
+
+export default { search };

--- a/src/controllers/atlassian.universal-search.controller.ts
+++ b/src/controllers/atlassian.universal-search.controller.ts
@@ -84,8 +84,16 @@ function buildTypeSpecificCql(
 ): string {
 	const clauses: string[] = [];
 
-	clauses.push(`type = ${SECTION_TO_CQL_TYPE[type]}`);
-	clauses.push(`text ~ "${escapeCqlValue(options.query)}"`);
+	const cqlType = SECTION_TO_CQL_TYPE[type];
+	const escapedQuery = escapeCqlValue(options.query);
+
+	clauses.push(`type = ${cqlType}`);
+
+	if (type === 'spaces') {
+		clauses.push(`title ~ "${escapedQuery}"`);
+	} else {
+		clauses.push(`(title ~ "${escapedQuery}" OR text ~ "${escapedQuery}")`);
+	}
 
 	if (type !== 'spaces' && options.spaceKey) {
 		clauses.push(`space = "${escapeCqlValue(options.spaceKey)}"`);

--- a/src/controllers/atlassian.universal-search.formatter.ts
+++ b/src/controllers/atlassian.universal-search.formatter.ts
@@ -1,0 +1,104 @@
+import { SearchResultType } from '../services/vendor.atlassian.search.types.js';
+import {
+	formatHeading,
+	formatBulletList,
+	formatNumberedList,
+	formatSeparator,
+	formatDate,
+} from '../utils/formatter.util.js';
+import { formatSearchResultItem } from './atlassian.search.formatter.js';
+
+export type UniversalSearchSectionKey =
+	| 'spaces'
+	| 'pages'
+	| 'blogPosts'
+	| 'attachments'
+	| 'comments';
+
+interface UniversalSearchFormatterInput {
+	query: string;
+	spaceKey?: string;
+	labels?: string[];
+	limitPerType: number;
+	includedTypes: UniversalSearchSectionKey[];
+	results: Record<UniversalSearchSectionKey, SearchResultType[]>;
+}
+
+const SECTION_TITLES: Record<UniversalSearchSectionKey, string> = {
+	spaces: 'Spaces',
+	pages: 'Pages',
+	blogPosts: 'Blog posts',
+	attachments: 'Attachments',
+	comments: 'Comments',
+};
+
+export function formatUniversalSearchResults(
+	input: UniversalSearchFormatterInput,
+): string {
+	const lines: string[] = [];
+
+	lines.push(formatHeading('Confluence Universal Search', 1));
+	lines.push('');
+
+	lines.push(formatHeading('Search Summary', 2));
+	const summaryItems: Record<string, unknown> = {
+		Query: `\`${input.query}\``,
+		'Limit per type': `${input.limitPerType} result${
+			input.limitPerType === 1 ? '' : 's'
+		} per category`,
+		'Included types': input.includedTypes
+			.map((type) => SECTION_TITLES[type])
+			.join(', '),
+	};
+
+	if (input.spaceKey) {
+		summaryItems['Space filter'] = input.spaceKey;
+	}
+
+	if (input.labels && input.labels.length > 0) {
+		summaryItems['Label filter'] = input.labels.join(', ');
+	}
+
+	lines.push(formatBulletList(summaryItems, (key) => key));
+	lines.push('');
+
+	let totalResults = 0;
+
+	for (const type of input.includedTypes) {
+		const sectionTitle = SECTION_TITLES[type];
+		const sectionResults = input.results[type] || [];
+		totalResults += sectionResults.length;
+
+		lines.push(
+			formatHeading(`${sectionTitle} (${sectionResults.length})`, 2),
+		);
+
+		if (sectionResults.length === 0) {
+			lines.push('_No results found in this category._');
+			lines.push('');
+			continue;
+		}
+
+		lines.push(
+			formatNumberedList(sectionResults, (result) =>
+				formatSearchResultItem(result),
+			),
+		);
+		lines.push('');
+	}
+
+	if (totalResults === 0) {
+		lines.push(
+			'_No matches were found across the selected content types. Try broadening your query or enabling more result types._',
+		);
+		lines.push('');
+	}
+
+	lines.push(formatSeparator());
+	lines.push(`*Information retrieved at: ${formatDate(new Date())}*`);
+	lines.push(
+		'_Tip: use `conf_search` (tool) or `mcp-atlassian-confluence search` (CLI) for advanced CQL filtering or pagination._',
+	);
+
+	return lines.join('\n').trim();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import cors from 'cors';
 import atlassianSpacesTools from './tools/atlassian.spaces.tool.js';
 import atlassianPagesTools from './tools/atlassian.pages.tool.js';
 import atlassianSearchTools from './tools/atlassian.search.tool.js';
+import atlassianUniversalSearchTools from './tools/atlassian.universal-search.tool.js';
 import atlassianCommentsTools from './tools/atlassian.comments.tool.js';
 import atlassianInlineCommentsTools from './tools/atlassian.inline-comments.tool.js';
 
@@ -75,6 +76,9 @@ export async function startServer(
 
 	atlassianSearchTools.registerTools(serverInstance);
 	serverLogger.debug('Registered Search tools');
+
+	atlassianUniversalSearchTools.registerTools(serverInstance);
+	serverLogger.debug('Registered Universal Search tools');
 
 	atlassianCommentsTools.registerTools(serverInstance);
 	serverLogger.debug('Registered Comments tools');

--- a/src/tools/atlassian.universal-search.tool.ts
+++ b/src/tools/atlassian.universal-search.tool.ts
@@ -1,0 +1,71 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { Logger } from '../utils/logger.util.js';
+import { formatErrorForMcpTool } from '../utils/error.util.js';
+import atlassianUniversalSearchController from '../controllers/atlassian.universal-search.controller.js';
+import {
+	UniversalSearchToolArgs,
+	UniversalSearchToolArgsType,
+} from './atlassian.universal-search.types.js';
+
+async function universalSearch(args: Record<string, unknown>) {
+	const methodLogger = Logger.forContext(
+		'tools/atlassian.universal-search.tool.ts',
+		'universalSearch',
+	);
+	methodLogger.debug('Universal search tool called with args:', args);
+
+	try {
+		const result = await atlassianUniversalSearchController.search(
+			args as UniversalSearchToolArgsType,
+		);
+
+		return {
+			content: [
+				{
+					type: 'text' as const,
+					text: result.content,
+				},
+			],
+		};
+	} catch (error) {
+		methodLogger.error('Universal search tool failed:', error);
+		return formatErrorForMcpTool(error);
+	}
+}
+
+function registerTools(server: McpServer) {
+	const toolLogger = Logger.forContext(
+		'tools/atlassian.universal-search.tool.ts',
+		'registerTools',
+	);
+	toolLogger.debug('Registering universal search MCP tool...');
+
+	const schema = z.object({
+		query: UniversalSearchToolArgs.shape.query,
+		spaceKey: UniversalSearchToolArgs.shape.spaceKey,
+		labels: UniversalSearchToolArgs.shape.labels,
+		includeSpaces: UniversalSearchToolArgs.shape.includeSpaces,
+		includePages: UniversalSearchToolArgs.shape.includePages,
+		includeBlogPosts: UniversalSearchToolArgs.shape.includeBlogPosts,
+		includeAttachments: UniversalSearchToolArgs.shape.includeAttachments,
+		includeComments: UniversalSearchToolArgs.shape.includeComments,
+		limitPerType: UniversalSearchToolArgs.shape.limitPerType,
+	});
+
+	server.tool(
+		'conf_search_all',
+		`Performs a single search across multiple Confluence content types (pages, blog posts, spaces, attachments, comments).
+- Provide a required \`query\` to search text content, titles, and excerpts.
+- Optional \`spaceKey\` filters content results (pages, blog posts, attachments, comments) to one space.
+- Optional \`labels\` require all provided labels on page/blog post results.
+- Enable/disable categories with \`include*\` flags or rely on defaults (all enabled).
+- Uses highlight excerpts and returns Markdown grouped by content type with result counts and tips.`,
+		schema.shape,
+		async (args: Record<string, unknown>) => universalSearch(args),
+	);
+
+	toolLogger.debug('Universal search MCP tool registered successfully');
+}
+
+export default { registerTools };

--- a/src/tools/atlassian.universal-search.types.ts
+++ b/src/tools/atlassian.universal-search.types.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+
+/**
+ * Arguments for the universal Confluence search tool.
+ */
+const UniversalSearchToolArgs = z.object({
+	query: z
+		.string()
+		.min(1)
+		.describe(
+			'Text to search for across Confluence pages, blog posts, spaces, attachments, and comments. Required.',
+		),
+	spaceKey: z
+		.string()
+		.optional()
+		.describe(
+			'Optional space key filter. When provided, only content within this space (pages, blog posts, comments, attachments) is returned.',
+		),
+	labels: z
+		.array(z.string())
+		.optional()
+		.describe(
+			'Optional labels to require on page and blog post results. All provided labels must be present on a result.',
+		),
+	includeSpaces: z
+		.boolean()
+		.optional()
+		.describe(
+			'Include Confluence spaces in the search results. Defaults to true.',
+		),
+	includePages: z
+		.boolean()
+		.optional()
+		.describe(
+			'Include Confluence pages in the search results. Defaults to true.',
+		),
+	includeBlogPosts: z
+		.boolean()
+		.optional()
+		.describe(
+			'Include Confluence blog posts in the search results. Defaults to true.',
+		),
+	includeAttachments: z
+		.boolean()
+		.optional()
+		.describe(
+			'Include Confluence attachments in the search results. Defaults to true.',
+		),
+	includeComments: z
+		.boolean()
+		.optional()
+		.describe(
+			'Include Confluence comments in the search results. Defaults to true.',
+		),
+	limitPerType: z
+		.number()
+		.int()
+		.positive()
+		.min(1)
+		.max(25)
+		.optional()
+		.describe(
+			'Maximum number of results to return for each selected content type (1-25). Defaults to 5.',
+		),
+});
+
+type UniversalSearchToolArgsType = z.infer<typeof UniversalSearchToolArgs>;
+
+export { UniversalSearchToolArgs, type UniversalSearchToolArgsType };

--- a/src/tools/atlassian.universal-search.types.ts
+++ b/src/tools/atlassian.universal-search.types.ts
@@ -8,7 +8,7 @@ const UniversalSearchToolArgs = z.object({
 		.string()
 		.min(1)
 		.describe(
-			'Text to search for across Confluence pages, blog posts, spaces, attachments, and comments. Required.',
+			'Text to search for across Confluence titles and full content (pages, blog posts, spaces, attachments, comments). Required.',
 		),
 	spaceKey: z
 		.string()

--- a/src/utils/cql.util.ts
+++ b/src/utils/cql.util.ts
@@ -1,0 +1,17 @@
+/**
+ * Utility helpers for working with Confluence Query Language (CQL).
+ * Provides functions for safely constructing CQL statements.
+ */
+
+/**
+ * Escape a value for safe inclusion inside CQL double quotes.
+ * Uses JSON.stringify to reuse the platform escaping rules and
+ * removes the wrapping quotes that JSON adds.
+ *
+ * @param value - Raw string value to escape for CQL usage
+ * @returns Escaped string suitable for use within a quoted CQL clause
+ */
+export function escapeCqlValue(value: string): string {
+	const jsonString = JSON.stringify(value);
+	return jsonString.slice(1, -1);
+}


### PR DESCRIPTION
## Summary
- add a universal search controller/formatter plus CLI command and MCP tool to query pages, spaces, attachments, comments, and blog posts together
- document the new `search-all` command in the README and register the handler with both the CLI entry point and MCP server
- extract a shared `escapeCqlValue` helper and shared search result formatter utility for reuse across search features

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c96ad6e5bc83338be93c3ad8d91e56