### PR TITLE
Ensure formatted links use Confluence host

### DIFF
--- a/src/controllers/atlassian.comments.formatter.ts
+++ b/src/controllers/atlassian.comments.formatter.ts
@@ -10,6 +10,10 @@ import {
 	formatSeparator,
 	formatNumberedList,
 } from '../utils/formatter.util.js';
+import {
+	ensureAbsoluteConfluenceUrl,
+	resolveConfluenceBaseUrl,
+} from '../utils/url.util.js';
 
 /**
  * Extended CommentData interface with the converted markdown body and highlighted text
@@ -32,6 +36,8 @@ export function formatCommentsList(
 	pageId: string,
 	baseUrl: string = '',
 ): string {
+	const resolvedBaseUrl = resolveConfluenceBaseUrl(baseUrl);
+
 	if (!commentsData || commentsData.length === 0) {
 		return (
 			'No comments found for this page.' +
@@ -94,9 +100,10 @@ export function formatCommentsList(
 
 			// Add link to the comment if available
 			if (comment._links?.webui) {
-				const commentUrl = comment._links.webui.startsWith('http')
-					? comment._links.webui
-					: `${baseUrl}${comment._links.webui}`;
+				const commentUrl = ensureAbsoluteConfluenceUrl(
+					comment._links.webui,
+					resolvedBaseUrl,
+				);
 
 				itemLines.push('');
 				itemLines.push(`[View comment in Confluence](${commentUrl})`);
@@ -113,8 +120,11 @@ export function formatCommentsList(
 	lines.push(`*Information retrieved at: ${formatDate(new Date())}*`);
 
 	// Add link to the page
-	if (baseUrl && pageId) {
-		const pageUrl = `${baseUrl}/pages/viewpage.action?pageId=${pageId}`;
+	if (pageId) {
+		const pageUrl = ensureAbsoluteConfluenceUrl(
+			`pages/viewpage.action?pageId=${pageId}`,
+			resolvedBaseUrl,
+		);
 		lines.push(`*View all comments on [this page](${pageUrl})*`);
 	}
 

--- a/src/controllers/atlassian.inline-comments.formatter.ts
+++ b/src/controllers/atlassian.inline-comments.formatter.ts
@@ -8,6 +8,10 @@ import {
 	formatHeading,
 	formatSeparator,
 } from '../utils/formatter.util.js';
+import {
+	ensureAbsoluteConfluenceUrl,
+	resolveConfluenceBaseUrl,
+} from '../utils/url.util.js';
 
 /**
  * Extended CommentData interface with the converted markdown body and highlighted text
@@ -36,6 +40,8 @@ export function formatInlineCommentsList(
 	start: number = 0,
 	limit: number = 25,
 ): string {
+	const resolvedBaseUrl = resolveConfluenceBaseUrl(baseUrl);
+
 	if (!commentsData || commentsData.length === 0) {
 		return (
 			formatHeading('Inline Comments', 1) +
@@ -137,9 +143,10 @@ export function formatInlineCommentsList(
 
 		// Add link to the comment if available
 		if (comment._links?.webui) {
-			const commentUrl = comment._links.webui.startsWith('http')
-				? comment._links.webui
-				: `${baseUrl}${comment._links.webui}`;
+			const commentUrl = ensureAbsoluteConfluenceUrl(
+				comment._links.webui,
+				resolvedBaseUrl,
+			);
 
 			lines.push('');
 			lines.push(`[🔗 View comment in Confluence](${commentUrl})`);
@@ -174,8 +181,11 @@ export function formatInlineCommentsList(
 	lines.push(`*Information retrieved at: ${formatDate(new Date())}*`);
 
 	// Add link to the page
-	if (baseUrl && pageId) {
-		const pageUrl = `${baseUrl}/pages/viewpage.action?pageId=${pageId}`;
+	if (pageId) {
+		const pageUrl = ensureAbsoluteConfluenceUrl(
+			`pages/viewpage.action?pageId=${pageId}`,
+			resolvedBaseUrl,
+		);
 		lines.push(
 			`*View all content and comments on [this page](${pageUrl})*`,
 		);

--- a/src/controllers/atlassian.pages.formatter.ts
+++ b/src/controllers/atlassian.pages.formatter.ts
@@ -11,6 +11,10 @@ import {
 	formatSeparator,
 	formatNumberedList,
 } from '../utils/formatter.util.js';
+import {
+	ensureAbsoluteConfluenceUrl,
+	resolveConfluenceBaseUrl,
+} from '../utils/url.util.js';
 
 /**
  * Format a list of pages for display
@@ -22,6 +26,8 @@ export function formatPagesList(
 	pagesData: PageSchemaType[],
 	baseUrl: string = '',
 ): string {
+	const resolvedBaseUrl = resolveConfluenceBaseUrl(baseUrl);
+
 	if (!pagesData || pagesData.length === 0) {
 		return (
 			'No Confluence pages found matching your criteria.' +
@@ -42,7 +48,10 @@ export function formatPagesList(
 		itemLines.push(formatHeading(page.title, 2));
 
 		// Create an object with all the properties to display
-		const pageUrl = `${baseUrl}/pages/viewpage.action?pageId=${page.id}`;
+		const pageUrl = ensureAbsoluteConfluenceUrl(
+			`pages/viewpage.action?pageId=${page.id}`,
+			resolvedBaseUrl,
+		);
 
 		const properties: Record<string, unknown> = {
 			ID: page.id,
@@ -83,11 +92,12 @@ export function formatPageDetails(
 	commentsSummary?: ControllerResponse | null,
 ): string {
 	// Create URL
-	const baseUrl = pageData._links.base || '';
+	const resolvedBaseUrl = resolveConfluenceBaseUrl(pageData._links.base);
 	const pageUrl = pageData._links.webui || '';
-	const fullUrl = pageUrl.startsWith('http')
-		? pageUrl
-		: `${baseUrl}${pageUrl}`;
+	const fullUrl = ensureAbsoluteConfluenceUrl(
+		pageUrl || `pages/viewpage.action?pageId=${pageData.id}`,
+		resolvedBaseUrl,
+	);
 
 	const lines: string[] = [
 		formatHeading(`Confluence Page: ${pageData.title}`, 1),
@@ -152,7 +162,10 @@ export function formatPageDetails(
 				lines.push('');
 
 				// Link to view all comments for this page
-				const allCommentsUrl = `${baseUrl}/pages/viewpage.action?pageId=${pageData.id}&showComments=true`;
+				const allCommentsUrl = ensureAbsoluteConfluenceUrl(
+					`pages/viewpage.action?pageId=${pageData.id}&showComments=true`,
+					resolvedBaseUrl,
+				);
 				lines.push(
 					`*${formatUrl(allCommentsUrl, 'View all comments on this page')}*`,
 				);

--- a/src/controllers/atlassian.search.formatter.ts
+++ b/src/controllers/atlassian.search.formatter.ts
@@ -6,6 +6,7 @@ import {
 	formatSeparator,
 	formatDate,
 } from '../utils/formatter.util.js';
+import { ensureAbsoluteConfluenceUrl } from '../utils/url.util.js';
 
 /**
  * Format search results for display
@@ -29,14 +30,15 @@ export function formatSearchResultItem(result: SearchResultType): string {
 		properties['Space ID'] = result.space.id;
 	}
 
-	const url =
+	const rawUrl =
 		result.url ||
 		result.content?._links?.webui ||
 		result.resultGlobalContainer?.displayUrl;
 
-	if (url) {
+	if (rawUrl) {
+		const absoluteUrl = ensureAbsoluteConfluenceUrl(rawUrl);
 		properties['URL'] = {
-			url,
+			url: absoluteUrl,
 			title: 'View in Confluence',
 		};
 	}

--- a/src/utils/url.util.test.ts
+++ b/src/utils/url.util.test.ts
@@ -1,0 +1,75 @@
+import {
+	ensureAbsoluteConfluenceUrl,
+	resolveConfluenceBaseUrl,
+} from './url.util.js';
+
+describe('url.util', () => {
+	const originalSiteName = process.env.ATLASSIAN_SITE_NAME;
+
+	afterEach(() => {
+		if (originalSiteName) {
+			process.env.ATLASSIAN_SITE_NAME = originalSiteName;
+		} else {
+			delete process.env.ATLASSIAN_SITE_NAME;
+		}
+	});
+
+	it('returns absolute URLs unchanged', () => {
+		const url = 'https://example.com/wiki/page';
+		expect(ensureAbsoluteConfluenceUrl(url)).toBe(url);
+	});
+
+	it('combines relative paths with absolute base URLs', () => {
+		const result = ensureAbsoluteConfluenceUrl(
+			'pages/viewpage.action?pageId=123',
+			'https://example.atlassian.net/wiki',
+		);
+
+		expect(result).toBe(
+			'https://example.atlassian.net/wiki/pages/viewpage.action?pageId=123',
+		);
+	});
+
+	it('normalizes leading slash paths when base includes /wiki', () => {
+		const result = ensureAbsoluteConfluenceUrl(
+			'/wiki/spaces/TEAM/pages/42',
+			'https://example.atlassian.net/wiki',
+		);
+
+		expect(result).toBe(
+			'https://example.atlassian.net/wiki/spaces/TEAM/pages/42',
+		);
+	});
+
+	it('uses site environment fallback when base is missing', () => {
+		process.env.ATLASSIAN_SITE_NAME = 'acme';
+
+		const result = ensureAbsoluteConfluenceUrl('spaces/ACME');
+
+		expect(result).toBe('https://acme.atlassian.net/wiki/spaces/ACME');
+	});
+
+	it('handles leading slash with environment fallback', () => {
+		process.env.ATLASSIAN_SITE_NAME = 'acme';
+
+		const result = ensureAbsoluteConfluenceUrl('/spaces/ACME');
+
+		expect(result).toBe('https://acme.atlassian.net/wiki/spaces/ACME');
+	});
+
+	it('returns original path when no base or environment is available', () => {
+		delete process.env.ATLASSIAN_SITE_NAME;
+
+		expect(ensureAbsoluteConfluenceUrl('/spaces/ACME')).toBe(
+			'/spaces/ACME',
+		);
+	});
+
+	it('resolves relative base URLs using environment', () => {
+		process.env.ATLASSIAN_SITE_NAME = 'acme';
+
+		const base = resolveConfluenceBaseUrl('/wiki');
+
+		expect(base).toBe('https://acme.atlassian.net/wiki');
+	});
+});

--- a/src/utils/url.util.ts
+++ b/src/utils/url.util.ts
@@ -1,0 +1,133 @@
+import { config } from './config.util.js';
+
+const HTTP_REGEX = /^https?:\/\//i;
+
+function getSiteHost(): string | undefined {
+	const siteName = config.get('ATLASSIAN_SITE_NAME');
+	if (!siteName) {
+		return undefined;
+	}
+	return `https://${siteName}.atlassian.net`;
+}
+
+function normalizeBaseUrl(baseUrl?: string): string | undefined {
+	const trimmed = baseUrl?.trim();
+
+	if (trimmed && HTTP_REGEX.test(trimmed)) {
+		return trimmed.replace(/\/+$/, '');
+	}
+
+	const siteHost = getSiteHost();
+
+	if (trimmed) {
+		if (siteHost) {
+			if (trimmed.startsWith('/')) {
+				return `${siteHost}${trimmed}`.replace(/\/+$/, '');
+			}
+
+			return `${siteHost}/${trimmed}`.replace(/\/+$/, '');
+		}
+
+		return trimmed.replace(/\/+$/, '');
+	}
+
+	if (siteHost) {
+		return `${siteHost}/wiki`.replace(/\/+$/, '');
+	}
+
+	return undefined;
+}
+
+function joinBaseAndPath(base: string, path: string): string {
+	const sanitizedBase = base.replace(/\/+$/, '');
+	if (!path) {
+		return sanitizedBase;
+	}
+
+	if (HTTP_REGEX.test(path)) {
+		return path;
+	}
+
+	const trimmedPath = path.trim();
+
+	if (!trimmedPath) {
+		return sanitizedBase;
+	}
+
+	if (trimmedPath.startsWith('/')) {
+		if (
+			sanitizedBase.endsWith('/wiki') &&
+			trimmedPath.startsWith('/wiki')
+		) {
+			return `${sanitizedBase}${trimmedPath.replace(/^\/wiki/, '')}`;
+		}
+
+		return `${sanitizedBase}${trimmedPath}`;
+	}
+
+	let relativePath = trimmedPath;
+
+	if (sanitizedBase.endsWith('/wiki') && relativePath.startsWith('wiki/')) {
+		relativePath = relativePath.slice('wiki/'.length);
+	}
+
+	return `${sanitizedBase}/${relativePath}`;
+}
+
+export function resolveConfluenceBaseUrl(baseUrl?: string): string {
+	const normalized = normalizeBaseUrl(baseUrl);
+	if (normalized) {
+		return normalized;
+	}
+	return baseUrl?.trim() || '';
+}
+
+export function ensureAbsoluteConfluenceUrl(
+	urlOrPath: string,
+	baseUrl?: string,
+): string {
+	const trimmedUrl = urlOrPath?.trim() || '';
+
+	if (!trimmedUrl) {
+		return trimmedUrl;
+	}
+
+	if (HTTP_REGEX.test(trimmedUrl)) {
+		return trimmedUrl;
+	}
+
+	const siteHost = getSiteHost();
+	const candidateBases: (string | undefined)[] = [];
+
+	if (baseUrl && HTTP_REGEX.test(baseUrl)) {
+		candidateBases.push(baseUrl);
+	} else {
+		candidateBases.push(resolveConfluenceBaseUrl(baseUrl));
+	}
+
+	if (siteHost) {
+		candidateBases.push(`${siteHost}/wiki`);
+		candidateBases.push(siteHost);
+	}
+
+	const seenBases = new Set<string>();
+
+	for (const candidate of candidateBases) {
+		if (!candidate) {
+			continue;
+		}
+
+		if (seenBases.has(candidate)) {
+			continue;
+		}
+
+		seenBases.add(candidate);
+
+		const combined = joinBaseAndPath(candidate, trimmedUrl);
+		if (combined) {
+			return combined;
+		}
+	}
+
+	return trimmedUrl;
+}


### PR DESCRIPTION
## Summary
- add shared utilities to resolve Confluence base URLs and guarantee absolute link generation
- update page, space, comment, inline comment, and search formatters to rely on the new helpers so every link opens the real Confluence site
- add focused tests covering URL normalization and fallback behavior

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbd80c3b588333acde3fb3362de851